### PR TITLE
Add missing scopes function in shopify.js in ChannelAdapters

### DIFF
--- a/channelAdapters/shopify.js
+++ b/channelAdapters/shopify.js
@@ -21,6 +21,10 @@ const REQUIRED_SCOPES = [
   "read_merchant_managed_fulfillment_orders",
 ];
 
+export function scopes(){
+  return REQUIRED_SCOPES
+}
+
 // Function to search products
 export async function searchProducts({ domain, accessToken, searchEntry }) {
   const shopifyClient = new GraphQLClient(


### PR DESCRIPTION
Fix(shopify): add missing `scopes` function in ChannelAdapters/shopify.js

This commit adds the missing `scopes()` function to the Shopify channel adapter.  
Without this, trying to connect a Shopify channel results in a -`TypeError: 
```
s is not a function` in the browser console.
```
<kbd><img width="1435" alt="Screenshot 2025-07-08 at 11 30 53 PM" src="https://github.com/user-attachments/assets/387bea73-4e57-41c8-8675-504537bbf378" /></kbd>

The error was triggered while attempting to install the Shopify app via the "Connect Channel" modal.  
Defining the `scopes()` function resolves the issue and aligns the adapter with expected behavior for OAuth-based integrations.



Tested locally and verified that the error no longer occurs after the fix.